### PR TITLE
fix: resolve ReferenceError, add input validation and robustness fixes in ES router

### DIFF
--- a/server/routes/client-routes.js
+++ b/server/routes/client-routes.js
@@ -5,13 +5,33 @@ const esUtils = require("../utility/ES-utils");
 
 const esDataSpaceClient = esUtils.getDataSpaceESClient();
 
+/**
+ * Helper: Safely parses req.query.body as JSON.
+ * Returns parsed object on success, or sends a 400 error response and returns null.
+ */
+function parseQueryBody(req, res) {
+  try {
+    const parsed = JSON.parse(req.query.body);
+    if (!parsed || typeof parsed !== "object") {
+      res.status(400).send({ error: "Query body must be a non-empty JSON object" });
+      return null;
+    }
+    return parsed;
+  } catch (e) {
+    res.status(400).send({ error: "Invalid query body: must be valid JSON" });
+    return null;
+  }
+}
+
 // autosuggest
 router.get("/auto-suggest", function (req, res) {
+  const body = parseQueryBody(req, res);
+  if (!body) return;
+
   esDataSpaceClient
     .search({
       index: "scigraph",
-      type: "_doc",
-      body: req.query.body,
+      body,
     })
     .then((response) => {
       res.send(response);
@@ -36,14 +56,21 @@ router.get("/find-by-slug", async function (req, res) {
 });
 
 router.get("/details", function (req, res) {
+  const body = parseQueryBody(req, res);
+  if (!body) return;
+
   esDataSpaceClient
     .search({
       index: "scigraph",
-      type: "_doc",
-      body: req.query.body,
+      body,
     })
     .then((response) => {
       res.send(response);
+    })
+    .catch((err) => {
+      console.error("Error occurred in details");
+      console.error(err);
+      res.status(500).send({ error: "Failed to fetch details" });
     });
 });
 
@@ -53,14 +80,18 @@ router.get("/all-data-by-entity", async function (req, res) {
   res.send(response);
 });
 
-/* this API is similar to al-data-by-entity
+/* this API is similar to all-data-by-entity
  * Key difference: above API fetches no data but aggregation
  */
-
 router.get("/all-data-by-free-text", async function (req, res) {
-  let esclientToUse = esDataSpaceClient;
+  const esclientToUse = esDataSpaceClient;
   const index = req.query.index || "scr*";
-  const handleCountResponse = (res, total_count) => {
+
+  // FIX 2: Validate and parse req.query.body before use
+  const query = parseQueryBody(req, res);
+  if (!query) return;
+
+  const handleCountResponse = (total_count) => {
     esclientToUse
       .search({
         index,
@@ -71,34 +102,41 @@ router.get("/all-data-by-free-text", async function (req, res) {
         res.send(response);
       })
       .catch((exp) => {
-        console.error("error occured in source-data-by-entity");
-        // console.error(req.query.body);
+        console.error("error occured in all-data-by-free-text search");
         console.error(exp);
         res.send([]);
       });
-  }
-  const query = JSON.parse(req.query.body);
+  };
+
   esclientToUse
     .count({
       index,
       body: {
-        query: query.query
+        query: query.query,
       },
-    }).then((response) => {
-      console.debug("check free data response")
-      console.debug(response)
-      handleCountResponse(res, response.count)
-    }).catch((exp) => {
-      console.debug("check free data exp")
-      console.debug(response)
-      handleCountResponse(res)
     })
+    .then((response) => {
+      console.debug("check free data response");
+      console.debug(response);
+      handleCountResponse(response.count);
+    })
+    .catch((exp) => {
+      // FIX 1: was logging undefined `response`, now correctly logs `exp`
+      console.debug("check free data exp");
+      console.debug(exp);
+      handleCountResponse();
+    });
 });
 
-
 router.get("/source-data-by-entity", function (req, res) {
+  // FIX 2: Validate and parse req.query.body before use
+  const query = parseQueryBody(req, res);
+  if (!query) return;
 
-  const handleCountResponse = (res, total_count) => {
+  const esclientToUse = esDataSpaceClient;
+
+  // FIX: moved esclientToUse declaration above handleCountResponse to avoid temporal dead zone
+  const handleCountResponse = (total_count) => {
     esclientToUse
       .search({
         index: req.query.source,
@@ -110,57 +148,71 @@ router.get("/source-data-by-entity", function (req, res) {
       })
       .catch((exp) => {
         console.error("error occured in source-data-by-entity");
-        // console.error(req.query.body);
         console.error(exp);
         res.send([]);
       });
-  }
+  };
 
-  let esclientToUse = esDataSpaceClient;
-  const query = JSON.parse(req.query.body);
   esclientToUse
     .count({
       index: req.query.source,
       body: {
-        query: query.query
+        query: query.query,
       },
-    }).then((response) => {
-      handleCountResponse(res, response.count)
-    }).catch((exp) => {
-      handleCountResponse(res)
-    })
-});
-
-//Literature
-router.get("/literature-by-curie-paths", function (req, res) {
-  esDataSpaceClient
-    .search({
-      index: "pubmed-19",
-      type: "_doc", // 'publication',
-      body: req.query.body,
     })
     .then((response) => {
-      res.send(response);
+      handleCountResponse(response.count);
+    })
+    .catch((exp) => {
+      console.error("error occurred in source-data-by-entity count");
+      console.error(exp);
+      handleCountResponse();
     });
 });
 
-//Training
+// Literature
+router.get("/literature-by-curie-paths", function (req, res) {
+  const body = parseQueryBody(req, res);
+  if (!body) return;
+
+  esDataSpaceClient
+    .search({
+      index: "pubmed-19",
+      body,
+    })
+    .then((response) => {
+      res.send(response);
+    })
+    .catch((err) => {
+      console.error("Error occurred in literature-by-curie-paths");
+      console.error(err);
+      res.status(500).send({ error: "Failed to fetch literature data" });
+    });
+});
+
+// Training
 router.get("/training-space-by-curie-paths", function (req, res) {
-  console.debug("check query")
-  console.debug(req.query)
+  console.debug("check query");
+  console.debug(req.query);
+
+  const body = parseQueryBody(req, res);
+  if (!body) return;
+
   esDataSpaceClient
     .search({
       index: "train_scr_022036_trainingspace",
-      body: req.query.body,
+      body,
     })
     .then((response) => {
-      console.debug("check training space response")
-      console.debug(response)
+      console.debug("check training space response");
+      console.debug(response);
       res.send(response);
-    }).catch((exp) => {
-      console.debug("check error in training space search")
-      console.debug(exp)
     })
+    .catch((exp) => {
+      console.error("Error occurred in training space search");
+      console.error(exp);
+      res.status(500).send({ error: "Failed to fetch training space data" });
+    });
 });
 
 module.exports = router;


### PR DESCRIPTION
# fix: resolve ReferenceError, add input validation and robustness fixes in ES router

## What changed and why

Two critical bugs fixed along with additional robustness improvements in the ES router.

---

### Fix 1 — `response` ReferenceError in `/all-data-by-free-text` #7 
`response` was logged in the `.count()` catch block but never declared in that scope,
causing a runtime crash. Replaced with `exp`.

```js
// Before
console.debug(response) 

// After
console.debug(exp) 
```

---

### Fix 2 — Missing Input Validation on `req.query.body` #8 
`req.query.body` was passed into ES queries with no validation. Added a shared
`parseQueryBody()` helper used across all routes, returning `400` on bad input.

```js
function parseQueryBody(req, res) {
  try {
    const parsed = JSON.parse(req.query.body);
    if (!parsed || typeof parsed !== "object") {
      res.status(400).send({ error: "Query body must be a non-empty JSON object" });
      return null;
    }
    return parsed;
  } catch (e) {
    res.status(400).send({ error: "Invalid query body: must be valid JSON" });
    return null;
  }
}
```

---

###  Additional Fixes
- Removed deprecated `type: "_doc"` from `/auto-suggest`, `/details`, `/literature-by-curie-paths`
- Fixed `esclientToUse` temporal dead zone in `/source-data-by-entity`
- Removed `res` parameter shadowing in `handleCountResponse`
- Added missing `.catch()` to `/details`, `/literature-by-curie-paths`, `/training-space-by-curie-paths`

---

## Test Checklist
- [ ] `/all-data-by-free-text` no longer crashes when `.count()` fails
- [ ] All routes return `400` on missing or invalid body
- [ ] All routes return `500` on ES failure instead of hanging
- [ ] No `type: "_doc"` deprecation warnings in ES logs